### PR TITLE
updated .vscode settings.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,12 @@
 {
   "python.pythonPath": "${workspaceFolder}/env/bin/python3",
   "editor.formatOnSave": true,
-  "python.linting.pep8Enabled": true,
+  "python.linting.pycodestyleEnabled": true,
   "python.linting.pylintEnabled": true,
   "python.linting.pylintPath": "pylint",
   "python.linting.pylintArgs": ["W0614", "--load-plugins", "pylint_django"],
   "python.venvPath": "${workspaceFolder}/env/bin/python3",
-  "python.linting.pep8Args": ["--ignore=E501"],
+  "python.linting.pycodestyleArgs": ["--ignore=E501"],
   "files.exclude": {
     "**/*.pyc": true
   }


### PR DESCRIPTION
The package used to be called pep8 , it is renamed to pycodestyle to reduce confusion as per official website pypi.org
link: https://pypi.org/project/pycodestyle/